### PR TITLE
Fixed bug for explicit null values

### DIFF
--- a/lib/nice-json2csv.js
+++ b/lib/nice-json2csv.js
@@ -39,7 +39,7 @@ var converter = {
     for(var i = 0; i < data.length; i++){ 
       var row = []; 
       _.forEach(columns, function(column){ 
-        var value = typeof data[i][column] == "object" && "[Object]" || data[i][column] || "";
+        var value = typeof data[i][column] == "object" && data[i][column] && "[Object]" || data[i][column] || "";
         row.push(value);
       }); 
       rows.push(row); 

--- a/test/converter.js
+++ b/test/converter.js
@@ -18,6 +18,11 @@ describe('The converter', function(){
     done();
   });
 
+  it('should return a blank value for explicit "null" value', function(done){
+    json2csv.convert([{ "a": "b", "c": "d"},{ "a": "b", "c": null}]).should.be.eql("\"a\",\"c\"\n\"b\",\"d\"\n\"b\",\"\"");
+    done();
+  });
+
   it('should correctly extend headers', function(done){
     json2csv.convert([{ "a": "b"},{ "a": "b", "c": "d"}]).should.be.eql("\"a\",\"c\"\n\"b\",\"\"\n\"b\",\"d\"");
     done();


### PR DESCRIPTION
Hey, i've found a bug and just fixed it (keeping your syntax): 'null' values were displayed as "[Object]"
Nice npm!
