### PR TITLE
Add UTF-8 BOM support

### DIFF
--- a/lib/nice-json2csv.js
+++ b/lib/nice-json2csv.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 
 var converter = {
   fixInput: function(parameter){
-    if(parameter && parameter.length == undefined && _.keys(parameter).length > 0) 
+    if(parameter && parameter.length == undefined && _.keys(parameter).length > 0)
       parameter = [parameter]; // data is a json object instead of an array of json objects
 
     return parameter;
@@ -20,11 +20,11 @@ var converter = {
                .replace(/],\[/g,'\n')
                .replace(/]]/g,'')
                .replace(/\[\[/g, '');
-  }, 
+  },
   convert: function(data, headers, suppressHeader){
-    if (!_.isBoolean(suppressHeader)) 
+    if (!_.isBoolean(suppressHeader))
       suppressHeader = false;
-    
+
     data = this.fixInput(data);
 
     if(data == null || data.length == 0)
@@ -33,29 +33,29 @@ var converter = {
     var columns = headers ? ((typeof headers == 'string') ? [headers] : headers) : this.getColumns(data);
     var rows = [];
 
-    if (!suppressHeader) 
+    if (!suppressHeader)
       rows.push(columns);
 
-    for(var i = 0; i < data.length; i++){ 
-      var row = []; 
-      _.forEach(columns, function(column){ 
+    for(var i = 0; i < data.length; i++){
+      var row = [];
+      _.forEach(columns, function(column){
         var value = typeof data[i][column] == "object" && data[i][column] && "[Object]" || data[i][column] || "";
         row.push(value);
-      }); 
-      rows.push(row); 
+      });
+      rows.push(row);
     }
 
     return this.convertToCsv(rows);
   },
-  decorateExpress: function(data, fileName, headers, suppressHeader){ 
+  decorateExpress: function(data, fileName, headers, suppressHeader){
 
     this.charset = this.charset || 'utf-8';
     this.header('Content-Type', 'text/csv');
     this.header('Content-disposition', 'attachment; filename=' + fileName);
 
     var body = converter.convert(data, headers, suppressHeader);
-    
-    return this.send(body);
+
+    return this.send('\ufeff' + body);
   }
 };
 


### PR DESCRIPTION
I don't know if is right that adding a parameter called `options`, so I just send a PR with utf8 BOM support, `.csv` file should be away from encoding problems

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/matteofigus/nice-json2csv/5)

<!-- Reviewable:end -->
