### PR TITLE
Allow date objects to be cast to string

### DIFF
--- a/lib/nice-json2csv.js
+++ b/lib/nice-json2csv.js
@@ -61,7 +61,7 @@ var converter = {
     if(_.isUndefined(item) || _.isNull(item))
       return '';
 
-    if(_.isObject(item))
+    if(_.isObject(item) && !(_.isDate(item)))
       return '[Object]';
 
     return item.toString();


### PR DESCRIPTION
I noticed dates in my data were getting output as [Object] in the csv file, so I added a check for Date objects so they will be passed along to .toString().