### PR TITLE
replace '\\"' with '""' for correct escaping of quotes.

### DIFF
--- a/lib/nice-json2csv.js
+++ b/lib/nice-json2csv.js
@@ -6,7 +6,8 @@ var converter = {
     return JSON.stringify(data)
                .replace(/],\[/g,'\n')
                .replace(/]]/g,'')
-               .replace(/\[\[/g, '');
+               .replace(/\[\[/g, '')
+               .replace(/\\"/g, '""');
   }, 
 
   convert: function(data, headers, suppressHeader){


### PR DESCRIPTION
According to the csv standard, correct escaping of quotation marks is a quotation mark. We noticed an open issue for this problem, and we decided to create a pull request with a fix.
As mentioned in the issue (https://github.com/matteofigus/nice-json2csv/issues/8), the fix is simply adding an extra replace to correctly add the quotation mark after the stringify function. :)